### PR TITLE
show successful testcase rather than a skipped one

### DIFF
--- a/bandit_formatter_junit/junit.py
+++ b/bandit_formatter_junit/junit.py
@@ -46,7 +46,6 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
         ).text = text
     if not issues:
         testcase = ET.SubElement(root, "testcase", name="NO-ISSUES")
-        ET.SubElement(testcase, "skipped", message="No issues found.")
 
     tree = ET.ElementTree(root)
 

--- a/bandit_formatter_junit/junit.py
+++ b/bandit_formatter_junit/junit.py
@@ -45,7 +45,7 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
             message=issue.text,
         ).text = text
     if not issues:
-        testcase = ET.SubElement(root, "testcase", name="NO-ISSUES")
+        ET.SubElement(root, "testcase", name="NO-ISSUES")
 
     tree = ET.ElementTree(root)
 


### PR DESCRIPTION
Thank you for this plugin ! it also enables bandit results reporting in Gitlab CI :1st_place_medal: 

However, I've had colleagues come confused about whether the bandit tests were run without finding issues, or skipped entirely.
 
This PR intends to remove the confusion by reporting a successful test case rather than a skipped one.

warning: I have noticed you've created the plugin to use it with Bamboo. I don't have access to a Bamboo account, so I unfortunately have no clue about how this change impacts reports there.